### PR TITLE
switching from singularity hub to syslabs cloud

### DIFF
--- a/EMaligner/distributed/src/Singularity.petsc_solver
+++ b/EMaligner/distributed/src/Singularity.petsc_solver
@@ -1,5 +1,5 @@
-Bootstrap: shub
-From: AllenInstitute/EM_aligner_python:petsc 
+Bootstrap: library
+From: djkapner/default/emaligner-petsc:v1.0.0
 
 %setup
     # singularity build should be run from repo base dir


### PR DESCRIPTION
We were using singularity hub for storing the PETSC base image, but that's been down for almost a week:
https://github.com/singularityhub/singularityhub.github.io/issues/173

Now there is a base image built and stored on syslabs and that is changed here.
(python 2.7 builds are now broken due to a new pytest release. Will fix separately)