### PR TITLE
trying to prevent pytest 5, which fails for python 2.7

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,7 +1,7 @@
 coverage>=4.1
 mock>=2.0.0
 pep8>=1.7.0
-pytest>=3.0.5
+pytest>4.6,<5.0
 pytest-cov>=2.2.1
 pytest-pep8>=1.0.6
 pytest-xdist>=1.14


### PR DESCRIPTION
pytest went from 4.6 to 5.0, but only for python > 3.4. The automatic solution mentioned here didn't just work
https://docs.pytest.org/en/latest/py27-py34-deprecation.html
so, we're sticking to 4.6, and can adjust when we ditch python 2.7: