### PR TITLE
Transform matches

### DIFF
--- a/EMaligner/EMaligner.py
+++ b/EMaligner/EMaligner.py
@@ -100,6 +100,18 @@ def calculate_processing_chunk(fargs):
     rhss = []
     for k, match in enumerate(matches):
 
+        # transform through
+        pxy = np.array(match['matches']['p']).transpose()
+        qxy = np.array(match['matches']['q']).transpose()
+        #for tf in tspecs[pinds[k]].tforms[1:-1]:
+        for tf in tspecs[pinds[k]].tforms[:-1]:
+            pxy = tf.tform(pxy)
+        #for tf in tspecs[qinds[k]].tforms[1:-1]:
+        for tf in tspecs[qinds[k]].tforms[:-1]:
+            qxy = tf.tform(qxy)
+        match['matches']['p'] = pxy.transpose().tolist()
+        match['matches']['q'] = qxy.transpose().tolist()
+
         pblock, qblock, weights, rhs = utils.blocks_from_tilespec_pair(
                 tspecs[pinds[k]],
                 tspecs[qinds[k]],

--- a/EMaligner/schemas.py
+++ b/EMaligner/schemas.py
@@ -158,15 +158,15 @@ class regularization(DefaultSchema):
         default=None,
         missing=None,
         cli_as_single_argument=True,
-        description=("List of regularization factors by order (0, 1, ...,  n).\n"
-                     "will override other settings for Polynomial2DTransform.\n"
-                     "multiplies default_lambda"))
+        description=("List of regularization factors by order "
+                     "(0, 1, ...,  n) will override other settings "
+                     "for Polynomial2DTransform. multiplies default_lambda"))
     thinplate_factor = Float(
         required=False,
         default=1e-5,
         missing=1e-5,
-        description=("regularization factor for thin plate spline control points"
-                     "multiplies default_lambda"))
+        description=("regularization factor for thin plate spline "
+                     "control points. multiplies default_lambda."))
 
 
 class input_db(db_params):
@@ -223,7 +223,8 @@ class output_stack(db_params):
         description="'stack' or 'pointmatch'")
     use_rest = Boolean(
         default=False,
-        description="passed as kwarg to renderapi.client.import_tilespecs_parallel")
+        description=("passed as kwarg to "
+                     "renderapi.client.import_tilespecs_parallel"))
 
     @mm.post_load
     def validate_file(self, data):
@@ -324,6 +325,13 @@ class EMA_Schema(ArgSchema):
             regularization,
             description=("options that contol the regularization of different"
                          " types of variables in the solve"))
+    transform_apply = List(
+            Int,
+            default=[],
+            missing=[],
+            description=("tilespec.tforms[i].tform() for i in transform_apply "
+                         "will be performed on the matches before matrix "
+                         "assembly."))
 
     @mm.post_load
     def validate_data(self, data):

--- a/EMaligner/utils.py
+++ b/EMaligner/utils.py
@@ -43,7 +43,8 @@ def make_dbconnection(collection, which='tile', interface=None):
     Returns
     -------
     dbconnection : obj
-        a multi-interface object used by other functions in :mod:`EMaligner.utils`
+        a multi-interface object used by other functions
+        in :mod:`EMaligner.utils`
 
     """
     if interface is None:
@@ -506,7 +507,7 @@ def write_reg_and_tforms(
 
 def get_stderr_stdout(outarg):
     """helper function for suppressing render output
-    
+
     Parameters
     ----------
     outarg : str
@@ -537,7 +538,7 @@ def write_to_new_stack(
         args,
         results):
     """write results to render or file output
-    
+
     Parameters
     ----------
     resolved : :class:`renderapi.resolvedtiles.ResolvedTiles`
@@ -677,7 +678,7 @@ def solve(A, weights, reg, x0, rhs):
 def message_from_solve_results(results):
     """create summarizing string message about solve for
        logging
-    
+
     Parameters
     ----------
     results : dict
@@ -741,7 +742,7 @@ def set_complete(stack):
 def get_z_values_for_stack(stack, zvals):
     """multi-interface wrapper to find overlapping z values
        between a stack and the requested range.
-    
+
     Parameters
     ----------
     stack : :class:`EMaligner.schema.input_stack`
@@ -889,3 +890,43 @@ def concatenate_results(results):
 
     return A, weights, rhs, zlist
 
+
+def transform_match(match, ptspec, qtspec, apply_list, tforms):
+    """transform the match coordinates through a subset of the
+       tilespec transform list
+
+    Parameters
+    ----------
+    match : dict
+        one match object
+    ptspec : :class:`renderapi.tilespec.TileSpec`
+        the tilespec for the p coordinates
+    qtspec : :class:`renderapi.tilespec.TileSpec`
+        the tilespec for the q coordinates
+    apply_list : list
+        list of indices for the transforms
+    tforms : list
+        list of reference transforms
+
+    Returns
+    -------
+    match : dict
+        one match object, with p and q transformed
+
+    """
+    if apply_list:
+        for tspec, pq in zip([ptspec, qtspec], ['p', 'q']):
+            try:
+                dst = renderapi.transform.estimate_dstpts(
+                        [tspec.tforms[i] for i in apply_list],
+                        src=np.array(match['matches'][pq]).transpose(),
+                        reference_tforms=tforms)
+            except IndexError:
+                logger.error("argument apply_list is {} but the tilespec "
+                             " for {} has tforms of length {}.".format(
+                                 apply_list,
+                                 tspec.tileId,
+                                 len(tspec.tforms)))
+                raise
+            match['matches'][pq] = dst.transpose().tolist()
+    return match


### PR DESCRIPTION
in some cases, we want to solve in transformed coordinates. For example, if for fine alignment, we have an input stack that has a transform list [lens, montage, rough, thinplate] where the thinplate is an identity placeholder for the new fine alignment transform, AND the point matches are in lens-corrected space, then a `transform_apply` specification of [1, 2] will apply the montage and rough transforms to the pointmatches before matrix assembly.
default is [] which does nothing, appropriate for montaging where we have [lens, affine(stage)] and the solver replaces the affine(stage) with affine or polynomial solution.
later, we could beef this up to operate on labels, instead of the iist, but, this is ok for now.