### PR TITLE
Distributed tweaks

### DIFF
--- a/EMaligner/EMaligner.py
+++ b/EMaligner/EMaligner.py
@@ -319,7 +319,8 @@ class EMaligner(argschema.ArgSchemaParser):
             if "results" in f.keys():
                 results = json.loads(f.get('results')[()][0].decode('utf-8'))
 
-            r = json.loads(f.get('resolved_tiles')[()][0].decode('utf-8'))
+            #r = json.loads(f.get('resolved_tiles')[()][0].decode('utf-8'))
+            r = json.loads(f.get('resolved_tiles')[()][0].tostring())
             self.resolvedtiles = renderapi.resolvedtiles.ResolvedTiles(json=r)
             logger.info(
                 "\n loaded %d tile specs from %s" % (

--- a/EMaligner/EMaligner.py
+++ b/EMaligner/EMaligner.py
@@ -100,6 +100,18 @@ def calculate_processing_chunk(fargs):
     rhss = []
     for k, match in enumerate(matches):
 
+        # transform through
+        pxy = np.array(match['matches']['p']).transpose()
+        qxy = np.array(match['matches']['q']).transpose()
+        #for tf in tspecs[pinds[k]].tforms[1:-1]:
+        for tf in tspecs[pinds[k]].tforms[:-1]:
+            pxy = tf.tform(pxy)
+        #for tf in tspecs[qinds[k]].tforms[1:-1]:
+        for tf in tspecs[qinds[k]].tforms[:-1]:
+            qxy = tf.tform(qxy)
+        match['matches']['p'] = pxy.transpose().tolist()
+        match['matches']['q'] = qxy.transpose().tolist()
+
         pblock, qblock, weights, rhs = utils.blocks_from_tilespec_pair(
                 tspecs[pinds[k]],
                 tspecs[qinds[k]],

--- a/EMaligner/EMaligner.py
+++ b/EMaligner/EMaligner.py
@@ -455,11 +455,10 @@ class EMaligner(argschema.ArgSchemaParser):
                 yield l[i:i + n]
 
         with renderapi.client.WithPool(self.args['n_parallel_jobs']) as pool:
-            # results = np.array(pool.map(calculate_processing_chunk, list(chunks(fargs, 10)))
             results = np.concatenate(
                     pool.map(
                         calculate_processing_chunk,
-                        list(chunks(fargs, 10))))
+                        list(chunks(fargs, self.args['processing_chunk_size']))))
 
         func_result['x'] = []
         reg = []

--- a/EMaligner/EMaligner.py
+++ b/EMaligner/EMaligner.py
@@ -320,8 +320,6 @@ class EMaligner(argschema.ArgSchemaParser):
             if "results" in f.keys():
                 results = json.loads(f.get('results')[()][0].decode('utf-8'))
 
-            #r = json.loads(f.get('resolved_tiles')[()][0].decode('utf-8'))
-            #r = json.loads(f.get('resolved_tiles')[()][0].tostring())
             r = f.get('resolved_tiles')[()][0]
             rname = os.path.join(
                     os.path.dirname(filename),

--- a/EMaligner/EMaligner.py
+++ b/EMaligner/EMaligner.py
@@ -35,102 +35,101 @@ def calculate_processing_chunk(fargs):
     """
     t0 = time.time()
     # set up for calling using multiprocessing pool
-    [pair, args, tspecs, tforms, col_ind, ncol] = fargs
-
-    tile_ids = np.array([t.tileId for t in tspecs])
-
+    [pair, args, tspecs, col_ind, ncol] = fargs[0]
+    chunks = []
     dbconnection = utils.make_dbconnection(args['pointmatch'])
-    sorter = np.argsort(tile_ids)
+    for farg in fargs:
+        [pair, args, tspecs, col_ind, ncol] = farg
 
-    # get point matches
-    nmatches = utils.get_matches(
-            pair['section1'],
-            pair['section2'],
-            args['pointmatch'],
-            dbconnection)
+        tile_ids = np.array([t.tileId for t in tspecs])
 
-    # extract IDs for fast checking
-    pid_set = set(m['pId'] for m in nmatches)
-    qid_set = set(m['qId'] for m in nmatches)
+        sorter = np.argsort(tile_ids)
 
-    tile_set = set(tile_ids)
 
-    pid_set.intersection_update(tile_set)
-    qid_set.intersection_update(tile_set)
-
-    matches = [m for m in nmatches if m['pId']
-               in pid_set and m['qId'] in qid_set]
-    del nmatches
-
-    if len(matches) == 0:
-        logger.debug(
-            "no tile pairs in "
-            "stack for pointmatch groupIds %s and %s" % (
-                pair['section1'], pair['section2']))
-        return None
-
-    pids = np.array([m['pId'] for m in matches])
-    qids = np.array([m['qId'] for m in matches])
-
-    logger.debug(
-            "loaded %d matches, using %d, "
-            "for groupIds %s and %s in %0.1f sec "
-            "using interface: %s" % (
-                len(pid_set.union(qid_set)),
-                len(matches),
+        # get point matches
+        nmatches = utils.get_matches(
                 pair['section1'],
                 pair['section2'],
-                time.time() - t0,
-                args['pointmatch']['db_interface']))
+                args['pointmatch'],
+                dbconnection)
 
-    # for the given point matches, these are the indices in tile_ids
-    # these determine the column locations in A for each tile pair
-    # this is a fast version of np.argwhere() loop
-    pinds = sorter[np.searchsorted(tile_ids, pids, sorter=sorter)]
-    qinds = sorter[np.searchsorted(tile_ids, qids, sorter=sorter)]
+        # extract IDs for fast checking
+        pid_set = set(m['pId'] for m in nmatches)
+        qid_set = set(m['qId'] for m in nmatches)
 
-    tilepair_weightfac = tilepair_weight(
-        pair['z1'],
-        pair['z2'],
-        args['matrix_assembly'])
+        tile_set = set(tile_ids)
 
-    wts = []
-    pblocks = []
-    qblocks = []
-    rhss = []
-    for k, match in enumerate(matches):
+        pid_set.intersection_update(tile_set)
+        qid_set.intersection_update(tile_set)
 
-        match = utils.transform_match(
-                match,
-                tspecs[pinds[k]],
-                tspecs[qinds[k]],
-                args['transform_apply'],
-                tforms)
+        matches = [m for m in nmatches if m['pId']
+                   in pid_set and m['qId'] in qid_set]
+        del nmatches
 
-        pblock, qblock, weights, rhs = utils.blocks_from_tilespec_pair(
-                tspecs[pinds[k]],
-                tspecs[qinds[k]],
-                match,
-                col_ind[pinds[k]],
-                col_ind[qinds[k]],
-                ncol,
-                args['matrix_assembly'])
+        if len(matches) == 0:
+            logger.debug(
+                "no tile pairs in "
+                "stack for pointmatch groupIds %s and %s" % (
+                    pair['section1'], pair['section2']))
+            return None
 
-        if pblock is None:
-            continue
+        pids = np.array([m['pId'] for m in matches])
+        qids = np.array([m['qId'] for m in matches])
 
-        pblocks.append(pblock)
-        qblocks.append(qblock)
-        wts.append(weights * tilepair_weightfac)
-        rhss.append(rhs)
+        logger.debug(
+                "loaded %d matches, using %d, "
+                "for groupIds %s and %s in %0.1f sec "
+                "using interface: %s" % (
+                    len(pid_set.union(qid_set)),
+                    len(matches),
+                    pair['section1'],
+                    pair['section2'],
+                    time.time() - t0,
+                    args['pointmatch']['db_interface']))
 
-    chunk = {}
-    chunk['zlist'] = np.array([pair['z1'], pair['z2']])
-    chunk['block'] = sparse.vstack(pblocks) - sparse.vstack(qblocks)
-    chunk['weights'] = np.concatenate(wts)
-    chunk['rhs'] = np.concatenate(rhss)
+        # for the given point matches, these are the indices in tile_ids
+        # these determine the column locations in A for each tile pair
+        # this is a fast version of np.argwhere() loop
+        pinds = sorter[np.searchsorted(tile_ids, pids, sorter=sorter)]
+        qinds = sorter[np.searchsorted(tile_ids, qids, sorter=sorter)]
 
-    return chunk
+        tilepair_weightfac = tilepair_weight(
+            pair['z1'],
+            pair['z2'],
+            args['matrix_assembly'])
+
+        wts = []
+        pblocks = []
+        qblocks = []
+        rhss = []
+        for k, match in enumerate(matches):
+
+            pblock, qblock, weights, rhs = utils.blocks_from_tilespec_pair(
+                    tspecs[pinds[k]],
+                    tspecs[qinds[k]],
+                    match,
+                    col_ind[pinds[k]],
+                    col_ind[qinds[k]],
+                    ncol,
+                    args['matrix_assembly'])
+
+            if pblock is None:
+                continue
+
+            pblocks.append(pblock)
+            qblocks.append(qblock)
+            wts.append(weights * tilepair_weightfac)
+            rhss.append(rhs)
+
+        chunk = {}
+        chunk['zlist'] = np.array([pair['z1'], pair['z2']])
+        chunk['block'] = sparse.vstack(pblocks) - sparse.vstack(qblocks)
+        chunk['weights'] = np.concatenate(wts)
+        chunk['rhs'] = np.concatenate(rhss)
+
+        chunks.append(chunk)
+
+    return chunks
 
 
 def tilepair_weight(z1, z2, matrix_assembly):
@@ -451,8 +450,16 @@ class EMaligner(argschema.ArgSchemaParser):
             col_ind[pair['ind']],
             col_ind.max()] for pair in pairs]
 
+        def chunks(l, n):
+            for i in range(0, len(l), n):
+                yield l[i:i + n]
+
         with renderapi.client.WithPool(self.args['n_parallel_jobs']) as pool:
-            results = np.array(pool.map(calculate_processing_chunk, fargs))
+            # results = np.array(pool.map(calculate_processing_chunk, list(chunks(fargs, 10)))
+            results = np.concatenate(
+                    pool.map(
+                        calculate_processing_chunk,
+                        list(chunks(fargs, 10))))
 
         func_result['x'] = []
         reg = []

--- a/EMaligner/EMaligner.py
+++ b/EMaligner/EMaligner.py
@@ -3,6 +3,7 @@ import renderapi
 import argschema
 from .schemas import EMA_Schema
 from . import utils
+from . import jsongz
 import time
 import scipy.sparse as sparse
 from scipy.sparse import csr_matrix
@@ -320,8 +321,14 @@ class EMaligner(argschema.ArgSchemaParser):
                 results = json.loads(f.get('results')[()][0].decode('utf-8'))
 
             #r = json.loads(f.get('resolved_tiles')[()][0].decode('utf-8'))
-            r = json.loads(f.get('resolved_tiles')[()][0].tostring())
-            self.resolvedtiles = renderapi.resolvedtiles.ResolvedTiles(json=r)
+            #r = json.loads(f.get('resolved_tiles')[()][0].tostring())
+            r = f.get('resolved_tiles')[()][0]
+            rname = os.path.join(
+                    os.path.dirname(filename),
+                    r)
+            self.resolvedtiles = renderapi.resolvedtiles.ResolvedTiles(
+                    json=jsongz.load(rname))
+
             logger.info(
                 "\n loaded %d tile specs from %s" % (
                     len(self.resolvedtiles.tilespecs),

--- a/EMaligner/EMaligner.py
+++ b/EMaligner/EMaligner.py
@@ -36,11 +36,11 @@ def calculate_processing_chunk(fargs):
     """
     t0 = time.time()
     # set up for calling using multiprocessing pool
-    [pair, args, tspecs, col_ind, ncol] = fargs[0]
+    [pair, args, tspecs, tforms, col_ind, ncol] = fargs[0]
     chunks = []
     dbconnection = utils.make_dbconnection(args['pointmatch'])
     for farg in fargs:
-        [pair, args, tspecs, col_ind, ncol] = farg
+        [pair, args, tspecs, tforms, col_ind, ncol] = farg
 
         tile_ids = np.array([t.tileId for t in tspecs])
 
@@ -104,6 +104,13 @@ def calculate_processing_chunk(fargs):
         qblocks = []
         rhss = []
         for k, match in enumerate(matches):
+
+            match = utils.transform_match(
+                match,
+                tspecs[pinds[k]],
+                tspecs[qinds[k]],
+                args['transform_apply'],
+                tforms)
 
             pblock, qblock, weights, rhs = utils.blocks_from_tilespec_pair(
                     tspecs[pinds[k]],

--- a/EMaligner/EMaligner.py
+++ b/EMaligner/EMaligner.py
@@ -461,10 +461,10 @@ class EMaligner(argschema.ArgSchemaParser):
                 yield l[i:i + n]
 
         with renderapi.client.WithPool(self.args['n_parallel_jobs']) as pool:
-            results = np.concatenate(
-                    pool.map(
+            results =  pool.map(
                         calculate_processing_chunk,
-                        list(chunks(fargs, self.args['processing_chunk_size']))))
+                        list(chunks(fargs, self.args['processing_chunk_size'])))
+        results = np.concatenate([i for i in results if i])
 
         func_result['x'] = []
         reg = []

--- a/EMaligner/distributed/allen_example_script.pbs
+++ b/EMaligner/distributed/allen_example_script.pbs
@@ -16,6 +16,16 @@ simf=/allen/programs/celltypes/workgroups/em-connectomics/danielk/EM_aligner_pyt
 input=/allen/programs/celltypes/workgroups/em-connectomics/danielk/EM_aligner_python/solution_input.h5
 output=/allen/programs/celltypes/workgroups/em-connectomics/danielk/EM_aligner_python/tmp.h5
 
+rm -f tmphosts2
+touch tmphosts2
 cat $PBS_NODEFILE > tmphosts
+np_total=0
+for out in $(cat tmphosts)
+do
+np=$(pbsnodes $out | grep np | tr -dc '0-9')
+np=$((np / 2))
+np_total=$((np_total+np))
+echo $out:$np >> tmphosts2
+done
 
-mpiexec -np $PBS_NUM_NODES -f tmphosts singularity run --bind /allen:/allen $simf -input $input -output $output -ksp_type preonly -pc_type lu -log_view
+mpiexec -n $np_total -f tmphosts2 singularity run --bind /allen:/allen $simf -input $input -output $output -ksp_type preonly -pc_type lu -log_view

--- a/EMaligner/distributed/makefile
+++ b/EMaligner/distributed/makefile
@@ -5,7 +5,7 @@ endif
 
 allen: src/em_dist_solve.o chkopts
 	@echo ${CLINKER}
-	${CLINKER} -lpthread -o bin/em_dist_solve src/em_dist_solve.o  ${PETSC_KSP_LIB}
+	${CLINKER} -o bin/em_dist_solve src/em_dist_solve.o  ${PETSC_KSP_LIB}
 	${RM} src/em_dist_solve.o
 
 cori:

--- a/EMaligner/distributed/makefile
+++ b/EMaligner/distributed/makefile
@@ -5,7 +5,7 @@ endif
 
 allen: src/em_dist_solve.o chkopts
 	@echo ${CLINKER}
-	${CLINKER} -openmp -o bin/em_dist_solve src/em_dist_solve.o  ${PETSC_KSP_LIB}
+	${CLINKER} -lpthread -o bin/em_dist_solve src/em_dist_solve.o  ${PETSC_KSP_LIB}
 	${RM} src/em_dist_solve.o
 
 cori:

--- a/EMaligner/distributed/makefile
+++ b/EMaligner/distributed/makefile
@@ -5,7 +5,7 @@ endif
 
 allen: src/em_dist_solve.o chkopts
 	@echo ${CLINKER}
-	${CLINKER} -o bin/em_dist_solve src/em_dist_solve.o  ${PETSC_KSP_LIB}
+	${CLINKER} -openmp -o bin/em_dist_solve src/em_dist_solve.o  ${PETSC_KSP_LIB}
 	${RM} src/em_dist_solve.o
 
 cori:

--- a/EMaligner/distributed/src/em_dist_solve.c
+++ b/EMaligner/distributed/src/em_dist_solve.c
@@ -54,7 +54,7 @@ main (int argc, char **args)
   int mpisupp;
 
   /*  Command line handling and setup  */
-  MPI_Init_thread (0, 0, MPI_THREAD_FUNNELED, &mpisupp);
+  MPI_Init_thread (0, 0, MPI_THREAD_MULTIPLE, &mpisupp);
 
   ierr = PetscInitialize (&argc, &args, (char *) 0, help);
   if (ierr)

--- a/EMaligner/distributed/src/em_dist_solve.c
+++ b/EMaligner/distributed/src/em_dist_solve.c
@@ -256,6 +256,8 @@ main (int argc, char **args)
   CHKERRQ (ierr);
   ierr = KSPSetFromOptions (ksp);
   CHKERRQ (ierr);
+  ierr = KSPSetReusePreconditioner(ksp, PETSC_TRUE);
+  CHKERRQ (ierr);
 
   /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
      Solve the linear system

--- a/EMaligner/distributed/src/em_dist_solve.c
+++ b/EMaligner/distributed/src/em_dist_solve.c
@@ -133,7 +133,10 @@ main (int argc, char **args)
 		  local_rhs);
   CHKERRQ (ierr);
   /*  Create distributed A!  */
-  MatCreateMPIAIJWithArrays (PETSC_COMM_WORLD, local_nrow, PETSC_DECIDE,
+  //MatCreateMPIAIJWithArrays (PETSC_COMM_WORLD, local_nrow, PETSC_DECIDE,
+  //			     global_nrow, global_ncol, local_indptr,
+  //			     local_jcol, local_data, &A);
+  MatCreateMPISBAIJWithArrays (PETSC_COMM_WORLD, 1, local_nrow, PETSC_DECIDE,
 			     global_nrow, global_ncol, local_indptr,
 			     local_jcol, local_data, &A);
   free (local_jcol);

--- a/EMaligner/distributed/src/em_dist_solve.c
+++ b/EMaligner/distributed/src/em_dist_solve.c
@@ -101,7 +101,7 @@ main (int argc, char **args)
   int count, j, nnodes, thisnode, noderank;
   MPI_Comm MPI_COMM_NODE;
   nodes = hw_config (MPI_COMM_WORLD, &nnodes, &thisnode);
-  split_files (nodes, nnodes, 373);
+  split_files (nodes, nnodes, nfiles);
   MPI_Comm_split (MPI_COMM_WORLD, thisnode, rank, &MPI_COMM_NODE);
   MPI_Comm_rank (MPI_COMM_NODE, &noderank);
   /*  what files will this rank read  */

--- a/EMaligner/distributed/src/em_dist_solve.c
+++ b/EMaligner/distributed/src/em_dist_solve.c
@@ -54,7 +54,7 @@ main (int argc, char **args)
   int mpisupp;
 
   /*  Command line handling and setup  */
-  MPI_Init_thread (0, 0, MPI_THREAD_MULTIPLE, &mpisupp);
+  MPI_Init_thread (0, 0, MPI_THREAD_FUNNELED, &mpisupp);
 
   ierr = PetscInitialize (&argc, &args, (char *) 0, help);
   if (ierr)

--- a/EMaligner/distributed/src/em_dist_solve.c
+++ b/EMaligner/distributed/src/em_dist_solve.c
@@ -133,12 +133,12 @@ main (int argc, char **args)
 		  local_rhs);
   CHKERRQ (ierr);
   /*  Create distributed A!  */
-  //MatCreateMPIAIJWithArrays (PETSC_COMM_WORLD, local_nrow, PETSC_DECIDE,
+  MatCreateMPIAIJWithArrays (PETSC_COMM_WORLD, local_nrow, PETSC_DECIDE,
+  			     global_nrow, global_ncol, local_indptr,
+  	                     local_jcol, local_data, &A);
+  //MatCreateMPISBAIJWithArrays (PETSC_COMM_WORLD, 1, local_nrow, PETSC_DECIDE,
   //			     global_nrow, global_ncol, local_indptr,
   //			     local_jcol, local_data, &A);
-  MatCreateMPISBAIJWithArrays (PETSC_COMM_WORLD, 1, local_nrow, PETSC_DECIDE,
-			     global_nrow, global_ncol, local_indptr,
-			     local_jcol, local_data, &A);
   free (local_jcol);
   free (local_data);
   free (local_indptr);

--- a/EMaligner/distributed/src/em_dist_solve.c
+++ b/EMaligner/distributed/src/em_dist_solve.c
@@ -211,8 +211,6 @@ main (int argc, char **args)
   ierr = MatMatMult (ATW, A, MAT_INITIAL_MATRIX, PETSC_DEFAULT, &K);
   CHKERRQ (ierr);
 
-  MatDestroy (&A);
-
   /*  find out how the rows are distributed   */
   MatGetOwnershipRange (K, &local_row0, &local_rowN);
   MatGetSize (K, &global_nrow, NULL);
@@ -354,41 +352,7 @@ main (int argc, char **args)
   strcat (strout, "\n");
   strcat (results_out, "],");
 
-
-  printf("destroying K\n");
   MatDestroy (&K);
-  printf("getting A again\n");
-
-  // we want A again. 
-  /*  allocate space for local CSR arrays  */
-  local_indptr = (PetscInt *) calloc (local_nrow + 1, sizeof (PetscInt));
-  local_jcol = (PetscInt *) calloc (local_nnz, sizeof (PetscInt));
-  local_data = (PetscScalar *) calloc (local_nnz, sizeof (PetscScalar));
-  local_weights = (PetscScalar *) calloc (local_nrow, sizeof (PetscScalar));
-  local_rhs = (PetscScalar **) malloc (nsolve * sizeof (PetscInt *));
-  for (i = 0; i < nsolve; i++)
-    {
-      local_rhs[i] =
-	(PetscScalar *) calloc (local_nrow, sizeof (PetscScalar));
-    }
-  /*  read in local hdf5 files and concatenate into CSR arrays  */
-  ierr =
-    ReadLocalCSR (PETSC_COMM_SELF, csrnames, local_firstfile, local_lastfile,
-		  nsolve, local_indptr, local_jcol, local_data, local_weights,
-		  local_rhs);
-  CHKERRQ (ierr);
-  printf("read stuff for A again\n");
-  /*  Create distributed A!  */
-  MatCreateMPIAIJWithArrays (PETSC_COMM_WORLD, local_nrow, PETSC_DECIDE,
-  			     global_nrow, global_ncol, local_indptr,
-  	                     local_jcol, local_data, &A);
-  free (local_jcol);
-  free (local_data);
-  free (local_indptr);
-  if (rank == 0)
-    {
-      printf ("A matrix created for error calculation\n");
-    }
 
   PetscInt mA, nA, c0, cn;
   ierr = MatGetSize (A, &mA, &nA);

--- a/EMaligner/distributed/src/em_dist_solve.c
+++ b/EMaligner/distributed/src/em_dist_solve.c
@@ -108,7 +108,10 @@ main (int argc, char **args)
   count = 0;
   for (i=0; i<nnodes; i++)
   {
-    disp_node (nodes[i]);
+    if (rank == 0)
+    {
+	    disp_node (nodes[i]);
+    }
     for (j=0; j<nodes[i].nrank; j++)
     {
       if ((thisnode == i) && (noderank == j))

--- a/EMaligner/distributed/src/em_dist_solve.c
+++ b/EMaligner/distributed/src/em_dist_solve.c
@@ -205,6 +205,9 @@ main (int argc, char **args)
   ierr = MatAXPY (K, (PetscScalar) 1.0, L, SUBSET_NONZERO_PATTERN);
   CHKERRQ (ierr);
   MatSetOption (K, MAT_SYMMETRIC, PETSC_TRUE);
+  // appropriate for Cholesky
+  ierr = MatConvert (K, MATMPISBAIJ, MAT_INPLACE_MATRIX, &K);
+  CHKERRQ (ierr);
 
   if (rank == 0)
     {

--- a/EMaligner/distributed/src/em_dist_solve.c
+++ b/EMaligner/distributed/src/em_dist_solve.c
@@ -354,7 +354,10 @@ main (int argc, char **args)
   strcat (strout, "\n");
   strcat (results_out, "],");
 
+
+  printf("destroying K\n");
   MatDestroy (&K);
+  printf("getting A again\n");
 
   // we want A again. 
   /*  allocate space for local CSR arrays  */
@@ -374,6 +377,7 @@ main (int argc, char **args)
 		  nsolve, local_indptr, local_jcol, local_data, local_weights,
 		  local_rhs);
   CHKERRQ (ierr);
+  printf("read stuff for A again\n");
   /*  Create distributed A!  */
   MatCreateMPIAIJWithArrays (PETSC_COMM_WORLD, local_nrow, PETSC_DECIDE,
   			     global_nrow, global_ncol, local_indptr,

--- a/EMaligner/distributed/src/em_dist_solve.c
+++ b/EMaligner/distributed/src/em_dist_solve.c
@@ -206,8 +206,8 @@ main (int argc, char **args)
   CHKERRQ (ierr);
   MatSetOption (K, MAT_SYMMETRIC, PETSC_TRUE);
   // appropriate for Cholesky
-  ierr = MatConvert (K, MATMPISBAIJ, MAT_INPLACE_MATRIX, &K);
-  CHKERRQ (ierr);
+  // ierr = MatConvert (K, MATMPISBAIJ, MAT_INPLACE_MATRIX, &K);
+  // CHKERRQ (ierr);
 
   if (rank == 0)
     {

--- a/EMaligner/distributed/src/hw_config.h
+++ b/EMaligner/distributed/src/hw_config.h
@@ -1,0 +1,271 @@
+#include "mpi.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <sys/sysinfo.h>
+
+typedef struct
+{
+  char *name;
+  double mem;
+  int *ranks;
+  int nrank;
+  double tmem;
+  int nfiles;
+  int *files;
+} node;
+
+void
+freenode (node inode)
+{
+  free (inode.name);
+  free (inode.ranks);
+  free (inode.files);
+}
+
+void
+disp_node (node inode)
+{
+  int i;
+  printf ("name %s mem %f nrank %d ranks", inode.name, inode.mem,
+	  inode.nrank);
+  for (i = 0; i < inode.nrank; i++)
+    {
+      printf (" %d", inode.ranks[i]);
+    }
+  printf (" tmem %f nfile %d nfiles", inode.tmem, inode.nfiles);
+  for (i = 0; i < inode.nrank; i++)
+  {
+      printf(" %d", inode.files[i]);
+  }
+  printf ("\n");
+}
+
+char *
+unique_str (char *in, int n, int m, int *nu)
+{
+  int i, j, c, *unique;
+  char *out;
+
+  unique = (int *) malloc (n * sizeof (int));
+
+  // just count first
+  for (i = 0; i < n; i++)
+    {
+      unique[i] = 1;
+      for (j = 0; j < i; j++)
+	{
+	  c = strcmp (&in[i * m], &in[j * m]);
+	  if (c == 0)
+	    {
+	      unique[i] = 0;
+	    }
+	}
+    }
+
+  *nu = 0;
+  for (i = 0; i < n; i++)
+    {
+      if (unique[i] == 1)
+	{
+	  *nu = *nu + 1;
+	}
+    }
+
+  // allocate and fill
+  out = (char *) malloc (m * (*nu) * sizeof (char));
+  j = 0;
+  for (i = 0; i < n; i++)
+    {
+      if (unique[i] == 1)
+	{
+	  sprintf (&out[j * m], &in[i * m]);
+	  j++;
+	}
+    }
+
+  free (unique);
+  return out;
+}
+
+node *
+index_rank (char *names, double *mem, int n, char *unames, int un, int mx)
+{
+  int i, j, k;
+  node *out;
+
+  out = (node *) malloc (un * sizeof (node));
+  for (j = 0; j < un; j++)
+    {
+      out[j].name = (char *) malloc (mx * sizeof (char));
+      sprintf (out[j].name, &unames[j * mx]);
+
+      // count the nodes
+      k = 0;
+      for (i = 0; i < n; i++)
+	{
+	  if (strcmp (&names[i * mx], &unames[j * mx]) == 0)
+	    {
+	      k++;
+	    }
+	}
+      out[j].nrank = k;
+      out[j].ranks = (int *) malloc (k * sizeof (int));
+      k = 0;
+
+
+      for (i = 0; i < n; i++)
+	{
+	  if (strcmp (&names[i * mx], &unames[j * mx]) == 0)
+	    {
+	      out[j].ranks[k] = i;
+	      out[j].mem = mem[i];
+	      k++;
+	    }
+	}
+    }
+  return out;
+}
+
+void
+split_files (node * nodes, int nnodes, int nfiles)
+{
+  int i, j, *f, t, m, k, ncpus;
+
+  f = (int *) malloc (nnodes * sizeof (int));
+
+  t = 0;
+  for (i = 0; i < nnodes; i++)
+    {
+      f[i] = floor (nfiles * nodes[i].mem / nodes[i].tmem);
+      t += f[i];
+    }
+
+  m = 0;
+  while (t < nfiles)
+    {
+      k = m % nnodes;
+      f[k]++;
+      t++;
+      m++;
+    }
+
+  for (i = 0; i < nnodes; i++)
+    {
+      nodes[i].nfiles = f[i];
+      nodes[i].files = (int *) malloc (nodes[i].nrank * sizeof(int));
+      t = 0;
+      for (j =0; j< nodes[i].nrank; j++){
+	      nodes[i].files[j] = floor (f[i] / nodes[i].nrank);
+	      t += nodes[i].files[j];
+      }
+      m = 0;
+      while (t < f[i]){
+          k = m % nodes[i].nrank;
+	  nodes[i].files[k]++;
+	  t++;
+	  m++;
+      }
+    }
+  
+  free (f);
+}
+
+
+node *
+hw_config (MPI_Comm COMM, int *nnodes, int *thisnode)
+{
+  int i, j, k, rank, nrank, len, nu, *inodes;
+  char name[MPI_MAX_PROCESSOR_NAME];
+  struct sysinfo si;
+  const double gigabyte = 1024 * 1024 * 1024;
+  char *names, *unames;
+  double tmem, rank_mem, *mem;
+  node *nodes;
+
+  sysinfo (&si);
+
+  MPI_Comm_size (COMM, &nrank);
+  MPI_Comm_rank (COMM, &rank);
+  MPI_Get_processor_name (name, &len);
+  rank_mem = si.totalram / gigabyte;
+
+  names = (char *) malloc (MPI_MAX_PROCESSOR_NAME * nrank * sizeof (char));
+  mem = (double *) malloc (nrank * sizeof (double));
+
+  // gather all the stats to rank 0
+  MPI_Gather (&rank_mem, 1, MPI_DOUBLE, mem, 1, MPI_DOUBLE, 0, COMM);
+  MPI_Gather (&name, MPI_MAX_PROCESSOR_NAME, MPI_CHAR, names,
+	      MPI_MAX_PROCESSOR_NAME, MPI_CHAR, 0, COMM);
+  // tell everyone
+  MPI_Bcast (names, nrank * MPI_MAX_PROCESSOR_NAME, MPI_CHAR, 0, COMM);
+  MPI_Bcast (mem, nrank, MPI_DOUBLE, 0, COMM);
+
+  unames = unique_str (names, nrank, MPI_MAX_PROCESSOR_NAME, &nu);
+  nodes = index_rank (names, mem, nrank, unames, nu, MPI_MAX_PROCESSOR_NAME);
+  tmem = 0;
+  for (i = 0; i < nu; i++)
+    {
+      tmem += nodes[i].mem;
+    }
+  for (i = 0; i < nu; i++)
+    {
+      nodes[i].tmem = tmem;
+    }
+  inodes = (int *) malloc (nrank * sizeof (int));
+  for (i = 0; i < nrank; i++)
+    {
+      for (j = 0; j < nu; j++)
+	{
+	  for (k = 0; k < nodes[j].nrank; k++)
+	    {
+	      if (nodes[j].ranks[k] == i)
+		{
+		  inodes[i] = j;
+		}
+	    }
+	}
+    }
+
+  *nnodes = nu;
+  *thisnode = inodes[rank];
+
+  free (names);
+  free (mem);
+  free (unames);
+  free (inodes);
+
+  return nodes;
+}
+
+//int
+//main (int argc, char *argv[])
+//{
+//  int i, rank, nnodes, thisnode, noderank;
+//  MPI_Comm MPI_COMM_NODE;
+//
+//  node *nodes;
+//  MPI_Init (&argc, &argv);
+//  MPI_Comm_rank (MPI_COMM_WORLD, &rank);
+//
+//  nodes = hw_config (MPI_COMM_WORLD, &nnodes, &thisnode);
+//  split_files (nodes, nnodes, 373);
+//
+//  if (rank == 0)
+//    {
+//      printf ("main %d nnodes\n", nnodes);
+//      for (i = 0; i < nnodes; i++)
+//	{
+//	  disp_node (nodes[i]);
+//	  freenode (nodes[i]);
+//	}
+//      free (nodes);
+//    }
+//
+//  MPI_Comm_split (MPI_COMM_WORLD, thisnode, rank, &MPI_COMM_NODE);
+//  MPI_Comm_rank (MPI_COMM_NODE, &noderank);
+//
+//  MPI_Finalize ();
+//  return 0;
+//}

--- a/EMaligner/schemas.py
+++ b/EMaligner/schemas.py
@@ -158,15 +158,15 @@ class regularization(DefaultSchema):
         default=None,
         missing=None,
         cli_as_single_argument=True,
-        description=("List of regularization factors by order (0, 1, ...,  n).\n"
-                     "will override other settings for Polynomial2DTransform.\n"
-                     "multiplies default_lambda"))
+        description=("List of regularization factors by order "
+                     "(0, 1, ...,  n) will override other settings "
+                     "for Polynomial2DTransform. multiplies default_lambda"))
     thinplate_factor = Float(
         required=False,
         default=1e-5,
         missing=1e-5,
-        description=("regularization factor for thin plate spline control points"
-                     "multiplies default_lambda"))
+        description=("regularization factor for thin plate spline "
+                     "control points. multiplies default_lambda."))
 
 
 class input_db(db_params):
@@ -223,7 +223,8 @@ class output_stack(db_params):
         description="'stack' or 'pointmatch'")
     use_rest = Boolean(
         default=False,
-        description="passed as kwarg to renderapi.client.import_tilespecs_parallel")
+        description=("passed as kwarg to "
+                     "renderapi.client.import_tilespecs_parallel"))
 
     @mm.post_load
     def validate_file(self, data):
@@ -324,6 +325,13 @@ class EMA_Schema(ArgSchema):
             regularization,
             description=("options that contol the regularization of different"
                          " types of variables in the solve"))
+    transform_apply = List(
+            Int,
+            default=[],
+            missing=[],
+            description=("tilespec.tforms[i].tform() for i in transform_apply "
+                         "will be performed on the matches before matrix "
+                         "assembly."))
 
     @mm.post_load
     def validate_data(self, data):

--- a/EMaligner/schemas.py
+++ b/EMaligner/schemas.py
@@ -257,6 +257,11 @@ class EMA_Schema(ArgSchema):
         description=("number of parallel jobs that will run for "
                      "retrieving tilespecs, assembly from pointmatches, "
                      "and import_tilespecs_parallel"))
+    processing_chunk_size = Int(
+        default=1,
+        required=False,
+        description=("number of pairs per multiprocessing job. can help "
+                     "parallelizing pymongo calls."))
     solve_type = String(
         default='montage',
         required=False,

--- a/EMaligner/utils.py
+++ b/EMaligner/utils.py
@@ -16,10 +16,10 @@ from . import jsongz
 import collections
 import itertools
 import subprocess
+import requests
 warnings.filterwarnings("ignore", message="numpy.dtype size changed")
 warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
 import h5py
-
 
 logger = logging.getLogger(__name__)
 
@@ -191,12 +191,15 @@ def get_resolved_from_z(stack, tform_name, fullsize, order, z):
     dbconnection = make_dbconnection(stack)
     if stack['db_interface'] == 'render':
         try:
+            s = requests.Session()
+            s.mount('http://', requests.adapters.HTTPAdapter(max_retries=5))
             resolved = renderapi.resolvedtiles.get_resolved_tiles_from_z(
                     stack['name'][0],
                     float(z),
                     render=dbconnection,
                     owner=stack['owner'],
-                    project=stack['project'])
+                    project=stack['project'],
+                    session=s)
         except renderapi.errors.RenderError:
             pass
     if stack['db_interface'] == 'mongo':

--- a/EMaligner/utils.py
+++ b/EMaligner/utils.py
@@ -191,15 +191,15 @@ def get_resolved_from_z(stack, tform_name, fullsize, order, z):
     dbconnection = make_dbconnection(stack)
     if stack['db_interface'] == 'render':
         try:
-            s = requests.Session()
-            s.mount('http://', requests.adapters.HTTPAdapter(max_retries=5))
-            resolved = renderapi.resolvedtiles.get_resolved_tiles_from_z(
-                    stack['name'][0],
-                    float(z),
-                    render=dbconnection,
-                    owner=stack['owner'],
-                    project=stack['project'],
-                    session=s)
+            with requests.Session() as s:
+                s.mount('http://', requests.adapters.HTTPAdapter(max_retries=5))
+                resolved = renderapi.resolvedtiles.get_resolved_tiles_from_z(
+                        stack['name'][0],
+                        float(z),
+                        render=dbconnection,
+                        owner=stack['owner'],
+                        project=stack['project'],
+                        session=s)
         except renderapi.errors.RenderError:
             pass
     if stack['db_interface'] == 'mongo':

--- a/EMaligner/utils.py
+++ b/EMaligner/utils.py
@@ -43,7 +43,8 @@ def make_dbconnection(collection, which='tile', interface=None):
     Returns
     -------
     dbconnection : obj
-        a multi-interface object used by other functions in :mod:`EMaligner.utils`
+        a multi-interface object used by other functions
+        in :mod:`EMaligner.utils`
 
     """
     if interface is None:
@@ -506,7 +507,7 @@ def write_reg_and_tforms(
 
 def get_stderr_stdout(outarg):
     """helper function for suppressing render output
-    
+
     Parameters
     ----------
     outarg : str
@@ -537,7 +538,7 @@ def write_to_new_stack(
         args,
         results):
     """write results to render or file output
-    
+
     Parameters
     ----------
     resolved : :class:`renderapi.resolvedtiles.ResolvedTiles`
@@ -677,7 +678,7 @@ def solve(A, weights, reg, x0, rhs):
 def message_from_solve_results(results):
     """create summarizing string message about solve for
        logging
-    
+
     Parameters
     ----------
     results : dict
@@ -741,7 +742,7 @@ def set_complete(stack):
 def get_z_values_for_stack(stack, zvals):
     """multi-interface wrapper to find overlapping z values
        between a stack and the requested range.
-    
+
     Parameters
     ----------
     stack : :class:`EMaligner.schema.input_stack`
@@ -889,3 +890,43 @@ def concatenate_results(results):
 
     return A, weights, rhs, zlist
 
+
+def transform_match(match, ptspec, qtspec, apply_list, tforms):
+    """transform the match coordinates through a subset of the
+       tilespec transform list
+
+    Parameters
+    ----------
+    match : dict
+        one match object
+    ptspec : :class:`renderapi.tilespec.TileSpec`
+        the tilespec for the p coordinates
+    qtspec : :class:`renderapi.tilespec.TileSpec`
+        the tilespec for the q coordinates
+    apply_list : list
+        list of indices for the transforms
+    tforms : list
+        list of reference transforms
+
+    Returns
+    -------
+    match : dict
+        one match object, with p and q transformed
+
+    """
+    if apply_list:
+        for tspec, pq in zip([ptspec, qtspec], ['p', 'q']):
+            try:
+                dst = renderapi.transform.estimate_dstpts(
+                        [tspec.tforms[i] for i in apply_list],
+                        src=np.array(match['matches'][pq]).transpose(),
+                        reference_tforms=tforms)
+            except IndexError:
+                logger.error("argument apply_list is {} but the tilespec "
+                             " for {} has tforms of length {}.".format(
+                                 apply_list,
+                                 tspec.tileId,
+                                 len(tspec.tforms)))
+                raise
+            match['matches'][pq] = dst.transpose().tolist()
+    return match

--- a/EMaligner/utils.py
+++ b/EMaligner/utils.py
@@ -483,8 +483,10 @@ def write_reg_and_tforms(
         dset = f.create_dataset(
                 "resolved_tiles",
                 (1,),
-                dtype=str_type)
-        dset[:] = json.dumps(resolved.to_dict(), indent=2)
+                data=np.void(json.dumps(
+                    resolved.to_dict(), indent=2)))
+        #        dtype=str_type)
+        # dset[:] = json.dumps(resolved.to_dict(), indent=2)
 
         # keep track of input args
         dset = f.create_dataset(

--- a/EMaligner/utils.py
+++ b/EMaligner/utils.py
@@ -310,22 +310,26 @@ def get_matches(iId, jId, collection, dbconnection):
         matches = [m for m in matches
                    if set([m['pGroupId'], m['qGroupId']]) & set([iId, jId])]
     if collection['db_interface'] == 'render':
-        if iId == jId:
-            for name in collection['name']:
-                matches.extend(renderapi.pointmatch.get_matches_within_group(
-                        name,
-                        iId,
-                        owner=collection['owner'],
-                        render=dbconnection))
-        else:
-            for name in collection['name']:
-                matches.extend(
-                        renderapi.pointmatch.get_matches_from_group_to_group(
+        with requests.Session() as s:
+            s.mount('http://', requests.adapters.HTTPAdapter(max_retries=5))
+            if iId == jId:
+                for name in collection['name']:
+                    matches.extend(renderapi.pointmatch.get_matches_within_group(
                             name,
                             iId,
-                            jId,
                             owner=collection['owner'],
-                            render=dbconnection))
+                            render=dbconnection,
+                            session=s))
+            else:
+                for name in collection['name']:
+                    matches.extend(
+                            renderapi.pointmatch.get_matches_from_group_to_group(
+                                name,
+                                iId,
+                                jId,
+                                owner=collection['owner'],
+                                render=dbconnection,
+                                session=s))
     if collection['db_interface'] == 'mongo':
         for dbconn in dbconnection:
             cursor = dbconn.collection.find(

--- a/EMaligner/utils.py
+++ b/EMaligner/utils.py
@@ -483,8 +483,10 @@ def write_reg_and_tforms(
         dset = f.create_dataset(
                 "resolved_tiles",
                 (1,),
-                data=np.void(json.dumps(
-                    resolved.to_dict(), indent=2)))
+                data=np.void(
+                    json.dumps(
+                        resolved.to_dict(),
+                        indent=2).encode()))
         #        dtype=str_type)
         # dset[:] = json.dumps(resolved.to_dict(), indent=2)
 

--- a/EMaligner/utils.py
+++ b/EMaligner/utils.py
@@ -480,13 +480,20 @@ def write_reg_and_tforms(
 
         str_type = h5py.special_dtype(vlen=bytes)
 
+        rname = os.path.join(
+                os.path.dirname(fname),
+                "resolved.json.gz")
+
         dset = f.create_dataset(
                 "resolved_tiles",
                 (1,),
-                data=np.void(
-                    json.dumps(
-                        resolved.to_dict(),
-                        indent=2).encode()))
+                data=os.path.basename(rname))
+
+        jsongz.dump(resolved.to_dict(), rname)
+        #        data=np.void(
+        #            json.dumps(
+        #                resolved.to_dict(),
+        #                indent=2).encode()))
         #        dtype=str_type)
         # dset[:] = json.dumps(resolved.to_dict(), indent=2)
 

--- a/EMaligner/utils.py
+++ b/EMaligner/utils.py
@@ -490,12 +490,6 @@ def write_reg_and_tforms(
                 data=os.path.basename(rname))
 
         jsongz.dump(resolved.to_dict(), rname)
-        #        data=np.void(
-        #            json.dumps(
-        #                resolved.to_dict(),
-        #                indent=2).encode()))
-        #        dtype=str_type)
-        # dset[:] = json.dumps(resolved.to_dict(), indent=2)
 
         # keep track of input args
         dset = f.create_dataset(


### PR DESCRIPTION
intent is to merge this after https://github.com/AllenInstitute/EM_aligner_python/pull/69
* `calculate_processing_chunk` is called with chunks now, controlled by `processing_chunk_size` parameter. This was an attempt to reuse pymongo connection objects. Did not necessarily result in performance improvments.
* Was trying to write resolved tiles json objects into the hdf5 file, so they could be read from there on ingest. This was not working well for some str/text/encoding issue. I decided to write the resolvedtiles.json.gz to disk and just record the relative path in the hdf5 file.
* `allen_example_script.pbs` has a way to count processors and send some modification of that count into mpiexec. This helps balance the desires of PETSc and PaStiX.
* related to above, new file `hwconfig.h` lets the distributed solver more evenly distribute reads across nodes.
* some custom request sessions with more retries, since some reads were failing with the default.
